### PR TITLE
[RFC] replace load_cert_chain with load_verify_locations

### DIFF
--- a/aiogremlin/driver/server.py
+++ b/aiogremlin/driver/server.py
@@ -27,11 +27,8 @@ class GremlinServer:
         scheme = config['scheme']
         if scheme in ['https', 'wss']:
             certfile = config['ssl_certfile']
-            keyfile = config['ssl_keyfile']
-            ssl_password = config['ssl_password']
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-            ssl_context.load_cert_chain(
-                certfile, keyfile=keyfile, password=ssl_password)
+            ssl_context.load_verify_locations(cafile=certfile)
             self._ssl_context = ssl_context
         else:
             self._ssl_context = None


### PR DESCRIPTION
This is purely a Request For Comment PR...

I don't have a good understanding of the SSL stack, but I'm trying to make `aiogremlin` work with AWS Neptune, which provides only a PEM file: https://docs.aws.amazon.com/neptune/latest/userguide/security-ssl.html

With these changes, I'm able to correctly connect to the server after getting the appropriate PEM file from here: https://www.amazontrust.com/repository/

Just based on reading Python docs, it seems that [load_verify_locations](https://docs.python.org/3.8/library/ssl.html#ssl.SSLContext.load_verify_locations) is the function we want to use if we want to add a Certification Authority to our SSL context... 

[load_cert_chain](https://docs.python.org/3.8/library/ssl.html#ssl.SSLContext.load_cert_chain) seems to be designed for validating private keys - but why would we have the private key in this situation?

PS: If this approach is accepted, I'd refactor the code a bit and also address the documentation here: https://aiogremlin.readthedocs.io/en/latest/usage.html#configuring-the-cluster-object

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/goblin-ogm/aiogremlin/2)
<!-- Reviewable:end -->
